### PR TITLE
Add missing include

### DIFF
--- a/src/sequential_lsm/lsm.cpp
+++ b/src/sequential_lsm/lsm.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdio>
 
 namespace kpq
 {


### PR DESCRIPTION
Without:

`#include <cstdio>`

I get the following compilation error:

```
.. klsm/src/sequential_lsm/lsm.cpp:233:15: error: ���printf��� was not declared in this scope
         printf("size: %d, capacity: %d, first: %d\n", m_size, m_capacity, m_first);
```
